### PR TITLE
Wrap __secure_getenv function

### DIFF
--- a/rpm/dnf.go
+++ b/rpm/dnf.go
@@ -4,6 +4,9 @@ package rpm
 
 // #cgo pkg-config: gio-2.0
 // #cgo pkg-config: libdnf
+// #cgo LDFLAGS: -Wl,--wrap=__secure_getenv
+//
+// #include "wrapper.h"
 // #include <libdnf/libdnf.h>
 //
 // typedef const gchar cgchar_t;

--- a/rpm/dnf.go
+++ b/rpm/dnf.go
@@ -4,7 +4,6 @@ package rpm
 
 // #cgo pkg-config: gio-2.0
 // #cgo pkg-config: libdnf
-//
 // #include <libdnf/libdnf.h>
 //
 // typedef const gchar cgchar_t;

--- a/rpm/dnf.go
+++ b/rpm/dnf.go
@@ -4,9 +4,7 @@ package rpm
 
 // #cgo pkg-config: gio-2.0
 // #cgo pkg-config: libdnf
-// #cgo LDFLAGS: -Wl,--wrap=__secure_getenv
 //
-// #include "wrapper.h"
 // #include <libdnf/libdnf.h>
 //
 // typedef const gchar cgchar_t;

--- a/rpm/glib.go
+++ b/rpm/glib.go
@@ -4,6 +4,9 @@ package rpm
 
 // #cgo pkg-config: gio-2.0
 // #cgo pkg-config: libdnf
+//
+// #cgo LDFLAGS: -Wl,--wrap=__secure_getenv
+// #include "wrapper.h"
 // #include <libdnf/libdnf.h>
 //
 // void gSignalConnect(gpointer obj, gchar *sig, GCallback callback, gpointer data)

--- a/rpm/wrapper.h
+++ b/rpm/wrapper.h
@@ -1,0 +1,35 @@
+/*
+Patch libdnf to remove references to glibc symbols which aren't forward-compatible.
+
+This is necessary because our build system compiles libdnf with glibc-2.16, but the 
+system-probe is compiled on a system with a more recent glibc version which doesn't
+contain the __secure_getenv symbol (in glibc 2.17, the symbol was renamed secure_getenv).
+*/
+
+#include <features.h>
+
+#if defined(__GLIBC__) && defined(__GLIBC_PREREQ) && __GLIBC_PREREQ(2, 17)
+
+#define symver_wrap___secure_getenv()                                  \
+char * ____secure_getenv_glibc_2_17(char const *name);                 \
+                                                                       \
+asm(".symver ____secure_getenv_glibc_2_17, secure_getenv@GLIBC_2.17"); \
+                                                                       \
+char * __wrap___secure_getenv (char const *name) {                     \
+  return ____secure_getenv_glibc_2_17(name);                           \
+}
+
+# else
+
+// Use the function directly for older glibc / non-glibc environments
+
+#define symver_wrap___secure_getenv()              \
+char * __secure_getenv(char const *name);          \
+                                                   \
+char * __wrap___secure_getenv (char const *name) { \
+  return __secure_getenv(name);                    \
+}
+
+#endif
+
+symver_wrap___secure_getenv()

--- a/rpm/wrapper.h
+++ b/rpm/wrapper.h
@@ -10,26 +10,12 @@ contain the __secure_getenv symbol (in glibc 2.17, the symbol was renamed secure
 
 #if defined(__GLIBC__) && defined(__GLIBC_PREREQ) && __GLIBC_PREREQ(2, 17)
 
-#define symver_wrap___secure_getenv()                                  \
-char * ____secure_getenv_glibc_2_17(char const *name);                 \
-                                                                       \
-asm(".symver ____secure_getenv_glibc_2_17, secure_getenv@GLIBC_2.17"); \
-                                                                       \
-char * __wrap___secure_getenv (char const *name) {                     \
-  return ____secure_getenv_glibc_2_17(name);                           \
-}
+char * ____secure_getenv_glibc_2_17(char const *name);
 
-# else
+asm(".symver ____secure_getenv_glibc_2_17, secure_getenv@GLIBC_2.17");
 
-// Use the function directly for older glibc / non-glibc environments
-
-#define symver_wrap___secure_getenv()              \
-char * __secure_getenv(char const *name);          \
-                                                   \
-char * __wrap___secure_getenv (char const *name) { \
-  return __secure_getenv(name);                    \
+char * __wrap___secure_getenv (char const *name) {
+  return ____secure_getenv_glibc_2_17(name);
 }
 
 #endif
-
-symver_wrap___secure_getenv()


### PR DESCRIPTION
This wraps the `__secure_getenv` so that nikos can be built on a system with glibc > 2.16 & be able to link successfully with a libdnf which was built with glibc <= 2.16.