### PR TITLE
Update commit for aptly-dev/aptly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,6 @@ require (
 	gopkg.in/yaml.v2 v2.2.8 // indirect
 )
 
-replace github.com/aptly-dev/aptly => github.com/lebauce/aptly v0.7.2-0.20201005164315-09522984a976
+replace github.com/aptly-dev/aptly => github.com/lebauce/aptly v0.7.2-0.20210723103859-345a32860f4d
 
 replace github.com/wille/osutil => github.com/lebauce/osutil v0.0.0-20201027170515-5409e8e42a87


### PR DESCRIPTION
Update `replace` directive from lebauce/aptly@09522984a976 (which was removed from the repo) to lebauce/aptly@345a32860f4d.

This was breaking Dependabot on the datadog-agent repository; I fixed it there but opened this PR for consistency https://github.com/DataDog/datadog-agent/network/updates/174999308