### PR TITLE
Wrap glibc log & pow functions

### DIFF
--- a/rpm/glib.go
+++ b/rpm/glib.go
@@ -5,7 +5,7 @@ package rpm
 // #cgo pkg-config: gio-2.0
 // #cgo pkg-config: libdnf
 //
-// #cgo LDFLAGS: -Wl,--wrap=__secure_getenv -Wl,--wrap=glob64 -Wl,--wrap=glob
+// #cgo LDFLAGS: -Wl,--wrap=__secure_getenv -Wl,--wrap=glob64 -Wl,--wrap=glob -Wl,--wrap=log -Wl,--wrap=pow
 // #include "wrapper.h"
 // #include <libdnf/libdnf.h>
 //

--- a/rpm/wrapper.h
+++ b/rpm/wrapper.h
@@ -57,4 +57,20 @@ int __wrap_glob(GLOB_ARGS) {
   return __glob_prior_glibc(pattern, flags, errfunc, pglob);
 }
 
+int __log_prior_glibc(double x);
+
+asm(".symver __log_prior_glibc, log@" GLIBC_VERS);
+
+double __wrap_log(double x) {
+  return __log_prior_glibc(x);
+}
+
+int __pow_prior_glibc(double x, double y);
+
+asm(".symver __pow_prior_glibc, pow@" GLIBC_VERS);
+
+double __wrap_pow(double x, double y) {
+  return __pow_prior_glibc(x, y);
+}
+
 #endif


### PR DESCRIPTION
Adds wrappers for the `log` and `pow` functions from the `libm` library in order to prevent symbols from GLIBC > 2.17.
(These functions were being wrapped in the system-probe by https://github.com/DataDog/datadog-agent/blob/main/pkg/ebpf/compiler/wrapper.h, which is why they weren't caught before)