### PR TITLE
Remove log & pow wrappers

### DIFF
--- a/rpm/dnf/dnf.go
+++ b/rpm/dnf/dnf.go
@@ -5,7 +5,7 @@ package dnf
 // #cgo pkg-config: gio-2.0
 // #cgo pkg-config: libdnf
 //
-// #cgo LDFLAGS: -Wl,--wrap=__secure_getenv -Wl,--wrap=glob64 -Wl,--wrap=glob -Wl,--wrap=log -Wl,--wrap=pow
+// #cgo LDFLAGS: -Wl,--wrap=__secure_getenv -Wl,--wrap=glob64 -Wl,--wrap=glob
 // #include "glib_wrapper.h"
 // #include "libdnf_wrapper.h"
 //

--- a/rpm/dnf/glib_wrapper.h
+++ b/rpm/dnf/glib_wrapper.h
@@ -60,22 +60,6 @@ int __wrap_glob(GLOB_ARGS) {
   return __glob_prior_glibc(pattern, flags, errfunc, pglob);
 }
 
-int __log_prior_glibc(double x);
-
-asm(".symver __log_prior_glibc, log@" GLIBC_VERS);
-
-double __wrap_log(double x) {
-  return __log_prior_glibc(x);
-}
-
-int __pow_prior_glibc(double x, double y);
-
-asm(".symver __pow_prior_glibc, pow@" GLIBC_VERS);
-
-double __wrap_pow(double x, double y) {
-  return __pow_prior_glibc(x, y);
-}
-
 #endif
 
 #endif /* GLIB_WRAPPER_H */


### PR DESCRIPTION
These definitions are conflicting with the ones in https://github.com/DataDog/datadog-agent/blob/main/pkg/ebpf/compiler/wrapper.h
