### PR TITLE
Put __wrap_log & __wrap_pow definitions into separate package

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -194,8 +194,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/lebauce/aptly v0.7.2-0.20201005164315-09522984a976 h1:AqaR29P5INgl7Uqwmu7kdbB7GYZIv/NsgUXUdnFXECg=
-github.com/lebauce/aptly v0.7.2-0.20201005164315-09522984a976/go.mod h1:+3II479yQc6qORocqKTXZQupY2SVnKPWDC2VMA7Zk9s=
+github.com/lebauce/aptly v0.7.2-0.20210723103859-345a32860f4d h1:6k4uyp3yRFzEmzQZjnneNYhIvNvvcu9XIvFyalzuBAE=
+github.com/lebauce/aptly v0.7.2-0.20210723103859-345a32860f4d/go.mod h1:Uot/EzgnIw6okZTyEZ/Q8+er5ZXy2Bqrrabr/M6OxUE=
 github.com/lebauce/osutil v0.0.0-20201027170515-5409e8e42a87 h1:38oaxSDpYgZiCmv3/g1QI+1fB/WaVJA89RLxkO8kKKY=
 github.com/lebauce/osutil v0.0.0-20201027170515-5409e8e42a87/go.mod h1:8mynkFldwsrffW4/Bp59D5bzt37KQcBzlnBysF6kyjc=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=

--- a/rpm/dnf/dnf.go
+++ b/rpm/dnf/dnf.go
@@ -5,7 +5,7 @@ package dnf
 // #cgo pkg-config: gio-2.0
 // #cgo pkg-config: libdnf
 //
-// #cgo LDFLAGS: -Wl,--wrap=__secure_getenv -Wl,--wrap=glob64 -Wl,--wrap=glob -Wl,--wrap=log -Wl,--wrap=pow
+// #cgo LDFLAGS: -Wl,--wrap=__secure_getenv -Wl,--wrap=glob64 -Wl,--wrap=glob
 // #include "glib_wrapper.h"
 // #include "libdnf_wrapper.h"
 //

--- a/rpm/dnf/glib_log_pow_wrapper.go
+++ b/rpm/dnf/glib_log_pow_wrapper.go
@@ -1,5 +1,5 @@
 // +build dnf
-// +build tests
+// +build molecule
 
 package dnf
 

--- a/rpm/dnf/glib_log_pow_wrapper.go
+++ b/rpm/dnf/glib_log_pow_wrapper.go
@@ -1,0 +1,8 @@
+// +build dnf
+// +build tests
+
+package dnf
+
+// #cgo LDFLAGS: -Wl,--wrap=log -Wl,--wrap=pow
+// #include "glib_log_pow_wrapper.h"
+import "C"

--- a/rpm/dnf/glib_log_pow_wrapper.h
+++ b/rpm/dnf/glib_log_pow_wrapper.h
@@ -1,0 +1,38 @@
+/*
+See glib_wrapper.h for an explanation of what this does & why we do it.
+*/
+
+#ifndef GLIB_LOG_POW_WRAPPER_H
+#define GLIB_LOG_POW_WRAPPER_H
+
+#include <features.h>
+
+#if defined(__GLIBC__) 
+
+#ifdef __x86_64__
+#define GLIBC_VERS "GLIBC_2.2.5"
+#elif defined(__aarch64__)
+#define GLIBC_VERS "GLIBC_2.17"
+#else
+#error Unknown architecture
+#endif
+
+int __log_prior_glibc(double x);
+
+asm(".symver __log_prior_glibc, log@" GLIBC_VERS);
+
+double __wrap_log(double x) {
+  return __log_prior_glibc(x);
+}
+
+int __pow_prior_glibc(double x, double y);
+
+asm(".symver __pow_prior_glibc, pow@" GLIBC_VERS);
+
+double __wrap_pow(double x, double y) {
+  return __pow_prior_glibc(x, y);
+}
+
+#endif
+
+#endif /* GLIB_LOG_POW_WRAPPER_H */

--- a/rpm/dnf/glib_wrapper.h
+++ b/rpm/dnf/glib_wrapper.h
@@ -12,6 +12,11 @@ Commands used to find symbols requiring a new version of GLIBC:
 $ objdump -p nikos
 // figure out which functions/symbols need that version
 $ nm nikos | grep GLIBC_2.27
+
+Additional glibc functions are wrapped in glib_log_pow_wrapper.h. Those functions had
+to be placed in a separate file so that they can be optionally included in the build through
+the use of the 'tests' build tag. This was necessary because they conflict with wrapper 
+functions defined in the datadog-agent source code.
 */
 
 #ifndef GLIB_WRAPPER_H
@@ -58,22 +63,6 @@ asm(".symver __glob_prior_glibc, glob@" GLIBC_VERS);
 
 int __wrap_glob(GLOB_ARGS) {
   return __glob_prior_glibc(pattern, flags, errfunc, pglob);
-}
-
-int __log_prior_glibc(double x);
-
-asm(".symver __log_prior_glibc, log@" GLIBC_VERS);
-
-double __wrap_log(double x) {
-  return __log_prior_glibc(x);
-}
-
-int __pow_prior_glibc(double x, double y);
-
-asm(".symver __pow_prior_glibc, pow@" GLIBC_VERS);
-
-double __wrap_pow(double x, double y) {
-  return __pow_prior_glibc(x, y);
 }
 
 #endif

--- a/tests/build_install_nikos.sh
+++ b/tests/build_install_nikos.sh
@@ -23,7 +23,7 @@ export PKG_CONFIG_PATH=$NIKOS_EMBEDDED_PATH/lib/pkgconfig
 export CGO_LDFLAGS="-L${NIKOS_EMBEDDED_PATH}/lib ${linker_flags} -static-libstdc++ -pthread -ldl -lm"
 
 # Build & install binary
-go build -tags "dnf tests" $SOURCE_FILES_PATH
+go build -tags "dnf molecule" $SOURCE_FILES_PATH
 
 sudo mkdir -p $NIKOS_BIN_PATH
 sudo mv nikos $NIKOS_BIN_PATH

--- a/tests/build_install_nikos.sh
+++ b/tests/build_install_nikos.sh
@@ -23,7 +23,7 @@ export PKG_CONFIG_PATH=$NIKOS_EMBEDDED_PATH/lib/pkgconfig
 export CGO_LDFLAGS="-L${NIKOS_EMBEDDED_PATH}/lib ${linker_flags} -static-libstdc++ -pthread -ldl -lm"
 
 # Build & install binary
-go build -tags dnf $SOURCE_FILES_PATH
+go build -tags "dnf tests" $SOURCE_FILES_PATH
 
 sudo mkdir -p $NIKOS_BIN_PATH
 sudo mv nikos $NIKOS_BIN_PATH


### PR DESCRIPTION
Pulls the `__wrap_log` and `__wrap_pow` functions into the `tests` package so that they can be optionally left out of the build. This was necessary because those definitions conflict with ones in https://github.com/DataDog/datadog-agent/blob/main/pkg/ebpf/compiler/wrapper.h. The functions couldn't be totally removed because they are necessary for running the molecule test suite.