### PR TITLE
Add support for yast2 repos

### DIFF
--- a/rpm/opensuse.go
+++ b/rpm/opensuse.go
@@ -45,7 +45,10 @@ func (b *OpenSUSEBackend) GetKernelHeaders(directory string) error {
 	}
 	err := b.dnfBackend.GetKernelHeaders(pkgNevra, directory)
 	if err == nil {
-		return nil
+		b.logger.Infof("successfully downloaded %s", pkgNevra)
+
+		// kernel-[flavour]-devel packages require kernel-devel
+		return b.dnfBackend.GetKernelHeaders("kernel-devel", directory)
 	}
 
 	b.logger.Infof("Error downloading package: %s. Retrying with the full set of repositories", err)

--- a/rpm/opensuse.go
+++ b/rpm/opensuse.go
@@ -48,7 +48,7 @@ func (b *OpenSUSEBackend) GetKernelHeaders(directory string) error {
 		b.logger.Infof("successfully downloaded %s", pkgNevra)
 
 		// kernel-[flavour]-devel packages require kernel-devel
-		return b.dnfBackend.GetKernelHeaders("kernel-devel", directory)
+		return b.dnfBackend.GetKernelHeaders("kernel-devel-"+kernelRelease, directory)
 	}
 
 	b.logger.Infof("Error downloading package: %s. Retrying with the full set of repositories", err)
@@ -57,8 +57,8 @@ func (b *OpenSUSEBackend) GetKernelHeaders(directory string) error {
 	}
 	err = b.dnfBackend.GetKernelHeaders(pkgNevra, directory)
 	if err == nil {
-	    b.logger.Infof("successfully downloaded %s", pkgNevra)
-	    return b.dnfBackend.GetKernelHeaders("kernel-devel", directory)
+		b.logger.Infof("successfully downloaded %s", pkgNevra)
+		return b.dnfBackend.GetKernelHeaders("kernel-devel-"+kernelRelease, directory)
 	}
 	return err
 }

--- a/rpm/opensuse.go
+++ b/rpm/opensuse.go
@@ -138,7 +138,7 @@ func NewOpenSUSEBackend(target *types.Target, reposDir string, logger types.Logg
 		logger.Warnf("Fail to convert yast2 repos to yum repos: %v", err)
 	} else {
 		reposDir = tmpReposDir
-		//defer os.RemoveAll(tmpReposDir)
+		defer os.RemoveAll(tmpReposDir)
 	}
 
 	dnfBackend, err := dnf.NewDnfBackend(target.Distro.Release, reposDir, logger, target)

--- a/rpm/opensuse.go
+++ b/rpm/opensuse.go
@@ -55,7 +55,12 @@ func (b *OpenSUSEBackend) GetKernelHeaders(directory string) error {
 	for _, repo := range disabledRepositories {
 		b.dnfBackend.EnableRepository(repo)
 	}
-	return b.dnfBackend.GetKernelHeaders(pkgNevra, directory)
+	err = b.dnfBackend.GetKernelHeaders(pkgNevra, directory)
+	if err == nil {
+	    b.logger.Infof("successfully downloaded %s", pkgNevra)
+	    return b.dnfBackend.GetKernelHeaders("kernel-devel", directory)
+	}
+	return err
 }
 
 // On newer versions of openSUSE, the repos are type yast2 instead of type yum.

--- a/rpm/opensuse.go
+++ b/rpm/opensuse.go
@@ -2,11 +2,15 @@ package rpm
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
 	"github.com/DataDog/nikos/rpm/dnf"
 	"github.com/DataDog/nikos/types"
+	"github.com/go-ini/ini"
 )
 
 type OpenSUSEBackend struct {
@@ -51,11 +55,71 @@ func (b *OpenSUSEBackend) GetKernelHeaders(directory string) error {
 	return b.dnfBackend.GetKernelHeaders(pkgNevra, directory)
 }
 
+// On newer versions of openSUSE, the repos are type yast2 instead of type yum.
+// For now, librepo only supports yum, so we need to convert the yast2 repo baseurls
+// to 'yum' format. Without this, attempting to download the repomd.xml file
+// results in a 404 error.
+func yumifyRepositories(reposDir string, logger types.Logger) (string, error) {
+	tmpDir, err := ioutil.TempDir("", "yum.repos.d")
+	if err != nil {
+		return "", err
+	}
+
+	repoFiles, err := filepath.Glob(reposDir + "/*.repo")
+	if err != nil {
+		os.RemoveAll(tmpDir)
+		return "", err
+	}
+
+	for _, repoFile := range repoFiles {
+		logger.Debugf("Reading repo file '%s'", repoFile)
+		cfg, err := ini.Load(repoFile)
+		if err != nil {
+			logger.Warnf("Fail to read file '%s': %v", repoFile, err)
+		}
+
+		if isYast2(cfg) {
+			sections := cfg.Sections()
+			for _, section := range sections {
+				if section.HasKey("baseurl") {
+					baseurl := section.Key("baseurl").String()
+					section.Key("baseurl").SetValue(baseurl + "suse/")
+				}
+			}
+		}
+
+		filename := filepath.Join(tmpDir, filepath.Base(repoFile))
+		if err := cfg.SaveTo(filename); err != nil {
+			logger.Warnf("Fail to write file '%s': %v", filename, err)
+		}
+	}
+
+	return tmpDir, nil
+}
+
+func isYast2(repoFile *ini.File) bool {
+	sections := repoFile.Sections()
+	for _, section := range sections {
+		if section.HasKey("type") {
+			return section.Key("type").String() == "yast2"
+		}
+	}
+	return false
+}
+
 func (b *OpenSUSEBackend) Close() {
 	b.dnfBackend.Close()
 }
 
 func NewOpenSUSEBackend(target *types.Target, reposDir string, logger types.Logger) (types.Backend, error) {
+	tmpReposDir, err := yumifyRepositories(reposDir, logger)
+	if err != nil {
+		logger.Warnf("Fail to convert yast2 repos to yum repos: %v", err)
+	} else {
+		reposDir = tmpReposDir
+		defer os.RemoveAll(tmpReposDir)
+	}
+
 	dnfBackend, err := dnf.NewDnfBackend(target.Distro.Release, reposDir, logger, target)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create DNF backend: %w", err)

--- a/tests/molecule/opensuse-container/molecule.yml
+++ b/tests/molecule/opensuse-container/molecule.yml
@@ -12,6 +12,12 @@ platforms:
     cpus: 1
     provider_options:
       disk_bus: '"sata"'
+  - name: opensuse42
+    box: generic/opensuse42
+    memory: 512
+    cpus: 1
+    provider_options:
+      disk_bus: '"sata"'
 provisioner:
   name: ansible
   env:

--- a/tests/molecule/opensuse-container/prepare.yml
+++ b/tests/molecule/opensuse-container/prepare.yml
@@ -13,14 +13,20 @@
       name: docker
       state: present
     become: true
-    when: ansible_distribution == 'openSUSE Leap' and ansible_os_family == 'Suse'
 
   - name: Install docker-py
     package:
       name: python3-docker
       state: present
     become: true
-    when: ansible_distribution == 'openSUSE Leap' and ansible_os_family == 'Suse'
+    when: ansible_distribution_major_version == '15'
+
+  - name: Install docker-py
+    package:
+      name: python-docker-py
+      state: present
+    become: true
+    when: ansible_distribution_major_version == '42'
 
   - name: Start docker
     service:

--- a/tests/molecule/opensuse-host/molecule.yml
+++ b/tests/molecule/opensuse-host/molecule.yml
@@ -12,6 +12,12 @@ platforms:
     cpus: 1
     provider_options:
       disk_bus: '"sata"'
+  - name: opensuse42
+    box: generic/opensuse42
+    memory: 512
+    cpus: 1
+    provider_options:
+      disk_bus: '"sata"'
 provisioner:
   name: ansible
   env:

--- a/types/types.go
+++ b/types/types.go
@@ -41,6 +41,7 @@ func NewTarget() (Target, error) {
 	}
 
 	platform = strings.Trim(platform, "\"")
+	version = strings.Trim(version, "\"")
 
 	target := Target{
 		Distro: Distro{

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,15 +1,23 @@
 package utils
 
 import (
-	"io/ioutil"
+	"io"
+	"os"
 )
 
-func CopyFile(src, dest string) error {
-	bytesRead, err := ioutil.ReadFile(src)
+func CopyFile(srcPath, destPath string) error {
+	dest, err := os.OpenFile(destPath, os.O_RDWR|os.O_CREATE, 0755)
 	if err != nil {
 		return err
 	}
+	defer dest.Close()
 
-	err = ioutil.WriteFile(dest, bytesRead, 0644)
+	src, err := os.Open(srcPath)
+	if err != nil {
+		return err
+	}
+	defer src.Close()
+
+	_, err = io.Copy(dest, src)
 	return err
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,0 +1,15 @@
+package utils
+
+import (
+	"io/ioutil"
+)
+
+func CopyFile(src, dest string) error {
+	bytesRead, err := ioutil.ReadFile(src)
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(dest, bytesRead, 0644)
+	return err
+}


### PR DESCRIPTION
Newer versions of openSUSE use `yast2` repos, and this type is not supported by librepo yet: see [librepo repo types](https://rpm-software-management.github.io/librepo/lib.html#repo-type-constants). Consequently, nikos assumes that the repos it is checking are type `yum`, and so it checks for the repomd.xml file in the default yum repo location (`repodata/repomd.xml`), when it’s actually located at `suse/repodata/repomd.xml`. As a result, it hits a 404 error and header downloading fails.

Until librepo adds support for `yast2` repos (not sure when exactly this will be, though we know it's in the works), we can work around this issue by copying the repo files, checking if they are type `yast2`, and adding `"suse/"` to the end of the baseurl if they are. This allows librepo to successfully find & use the `repomd.xml` file it requires.

Additional fix: previously, we weren't downloading the `kernel-devel` package, which is required by all `kernel-default-devel` packages: https://reposcope.com/package/kernel-default-devel/dependencies. This PR ensures we download both packages.
