### PR TITLE
Add missing version when creating SLES gpg url

### DIFF
--- a/rpm/sles.go
+++ b/rpm/sles.go
@@ -39,7 +39,7 @@ func (b *SLESBackend) GetKernelHeaders(directory string) error {
 			version = "SLE" + version
 			repoID := "Kernel_" + version
 			baseurl := fmt.Sprintf("https://download.opensuse.org/repositories/Kernel:/%s/standard/", version)
-			gpgKey := fmt.Sprintf("https://download.opensuse.org/repositories/Kernel:/%s/standard/repodata/repomd.xml.key")
+			gpgKey := fmt.Sprintf("https://download.opensuse.org/repositories/Kernel:/%s/standard/repodata/repomd.xml.key", version)
 
 			b.logger.Infof("Using with %s repository", repoID)
 			b.dnfBackend.AddRepository(repoID, baseurl, true, gpgKey, "", "", "")


### PR DESCRIPTION
The `Sprintf` is missing its argument.

Looking more deeply at the actual URL: should we actually fetch the gpg from there ? Even with a fixed URL I'm getting a 404