### PR TITLE
Fix CentOS 8 CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ commands:
             sudo dpkg -i vagrant_2.2.18_x86_64.deb 
 
       - run:
-          name: Install libvrt & qemu
+          name: Install libvirt & qemu
           command: |
             # Download any requirements that aren't already in the cache
             sudo mkdir -p apt-cache/archives

--- a/tests/molecule/centos-container/prepare.yml
+++ b/tests/molecule/centos-container/prepare.yml
@@ -21,6 +21,36 @@
     become: true
     when: ansible_distribution_major_version > '7'
 
+  - name: Find all repo files
+    find:
+      paths: /etc/yum.repos.d/
+      patterns: "CentOS*.repo"
+    become: true
+    register: repos
+    when: ansible_distribution_major_version > '7'
+
+  - name: Debug repos
+    debug:
+      var: repos
+
+  - name: Comment out mirrorlists
+    replace:
+      path: "{{ item.path }}"
+      regexp: 'mirrorlist'
+      replace: '#mirrorlist'
+    become: true
+    with_items: "{{ repos.files }}"
+    when: ansible_distribution_major_version > '7'
+
+  - name: Use vault instead of mirror
+    replace:
+      path: "{{ item.path }}"
+      regexp: '#baseurl=http://mirror.centos.org'
+      replace: 'baseurl=http://vault.centos.org'
+    become: true
+    with_items: "{{ repos.files }}"
+    when: ansible_distribution_major_version > '7'
+
   - name: Install Docker
     package:
       name: "{{ item }}"

--- a/tests/molecule/centos-container/prepare.yml
+++ b/tests/molecule/centos-container/prepare.yml
@@ -29,10 +29,6 @@
     register: repos
     when: ansible_distribution_major_version > '7'
 
-  - name: Debug repos
-    debug:
-      var: repos
-
   - name: Comment out mirrorlists
     replace:
       path: "{{ item.path }}"


### PR DESCRIPTION
Centos 8 being EOL, we need to fix the repos/mirrorlist to point to archive.

This PR implements the fix suggested in [this blog post](https://www.getpagespeed.com/server-setup/how-to-fix-dnf-after-centos-8-went-eol), but uses ansible tasks instead of sed