### PR TITLE
Fix nil pointer exception in tarball extraction by implementing zstd decompression

### DIFF
--- a/extract/tarball.go
+++ b/extract/tarball.go
@@ -15,7 +15,6 @@ import (
 )
 
 func ExtractTarball(reader io.Reader, filename, directory string, logger types.Logger) error {
-    logger.Debugf("Extracting file %s", filename)
 	var compressedTarReader io.Reader
 	var err error
 	switch filepath.Ext(filename) {
@@ -25,6 +24,8 @@ func ExtractTarball(reader io.Reader, filename, directory string, logger types.L
 		compressedTarReader, err = gzip.NewReader(reader)
 	case ".bz2":
 		compressedTarReader = bzip2.NewReader(reader)
+    default:
+        return fmt.Errorf("failed to extract %s", filename)
 	}
 
 	if err != nil {

--- a/extract/tarball.go
+++ b/extract/tarball.go
@@ -24,8 +24,8 @@ func ExtractTarball(reader io.Reader, filename, directory string, logger types.L
 		compressedTarReader, err = gzip.NewReader(reader)
 	case ".bz2":
 		compressedTarReader = bzip2.NewReader(reader)
-    default:
-        return fmt.Errorf("failed to extract %s", filename)
+	default:
+		return fmt.Errorf("failed to extract %s", filename)
 	}
 
 	if err != nil {

--- a/extract/tarball.go
+++ b/extract/tarball.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/DataDog/nikos/types"
+	"github.com/DataDog/zstd"
 	"github.com/xi2/xz"
 )
 
@@ -24,6 +25,10 @@ func ExtractTarball(reader io.Reader, filename, directory string, logger types.L
 		compressedTarReader, err = gzip.NewReader(reader)
 	case ".bz2":
 		compressedTarReader = bzip2.NewReader(reader)
+	case ".zst":
+		zstdReader := zstd.NewReader(reader)
+		defer zstdReader.Close()
+		compressedTarReader = zstdReader
 	default:
 		return fmt.Errorf("failed to extract %s", filename)
 	}

--- a/extract/tarball.go
+++ b/extract/tarball.go
@@ -15,6 +15,7 @@ import (
 )
 
 func ExtractTarball(reader io.Reader, filename, directory string, logger types.Logger) error {
+    logger.Debugf("Extracting file %s", filename)
 	var compressedTarReader io.Reader
 	var err error
 	switch filepath.Ext(filename) {

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	cloud.google.com/go/storage v1.12.0
 	github.com/AlekSi/pointer v1.1.0 // indirect
 	github.com/DataDog/gopsutil v0.0.0-20211112180027-9aa392ae181a
+	github.com/DataDog/zstd v1.5.0
 	github.com/DisposaBoy/JsonConfigReader v0.0.0-20171218180944-5ea4d0ddac55 // indirect
 	github.com/StackExchange/wmi v1.2.1 // indirect
 	github.com/acobaugh/osrelease v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,9 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/gopsutil v0.0.0-20211112231309-1e2204a98d89 h1:WiMz6zKlbUzQkEjivJ07djBdvuhHqga1UtSr0JA4dbU=
 github.com/DataDog/gopsutil v0.0.0-20211112231309-1e2204a98d89/go.mod h1:glkxNt/qRu9lnpmUEQwOIAXW+COWDTBOTEAHqbgBPts=
-github.com/DataDog/zstd v1.4.5 h1:EndNeuB0l9syBZhut0wns3gV1hL8zX8LIu6ZiVHWLIQ=
 github.com/DataDog/zstd v1.4.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
+github.com/DataDog/zstd v1.5.0 h1:+K/VEwIAaPcHiMtQvpLD4lqW7f0Gk3xdYZmI1hD+CXo=
+github.com/DataDog/zstd v1.5.0/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/DisposaBoy/JsonConfigReader v0.0.0-20130112093355-33a99fdf1d5e/go.mod h1:GCzqZQHydohgVLSIqRKZeTt8IGb1Y4NaFfim3H40uUI=
 github.com/DisposaBoy/JsonConfigReader v0.0.0-20171218180944-5ea4d0ddac55 h1:jbGlDKdzAZ92NzK65hUP98ri0/r50vVVvmZsFP/nIqo=
 github.com/DisposaBoy/JsonConfigReader v0.0.0-20171218180944-5ea4d0ddac55/go.mod h1:GCzqZQHydohgVLSIqRKZeTt8IGb1Y4NaFfim3H40uUI=


### PR DESCRIPTION
On recent versions of ubuntu (and maybe other distributions as well) the package manager can receive `data.tar.zst` files, resulting in `nil pointer exceptions`. This PR:
- fixes the default case to better handle the error case
- adds zstandard decompression support