### PR TITLE
Fix apt search path

### DIFF
--- a/apt/apt.go
+++ b/apt/apt.go
@@ -154,7 +154,7 @@ func (b *Backend) GetKernelHeaders(directory string) error {
 	query := &deb.FieldQuery{
 		Field:    "Name",
 		Relation: deb.VersionPatternMatch,
-		Value:    "linux-headers-" + kernelRelease + "*",
+		Value:    fmt.Sprintf("linux-headers-%s", kernelRelease),
 	}
 	b.logger.Infof("Looking for %s", query.Value)
 


### PR DESCRIPTION
On arm64, there is multiple similar flavor `generic` and `generic-64k` (the same but with 64k pages). This similarity causes issues when the apt search query is `linux-headers-$(uname -r)*`. This PR removes the `*`