### PR TITLE
include statement for libdnf.h moved out of c linkage block

### DIFF
--- a/rpm/dnf/libdnf_wrapper.h
+++ b/rpm/dnf/libdnf_wrapper.h
@@ -19,11 +19,11 @@ In order to keep memory management as straightforward as possible, the functions
 #ifndef LIBDNF_WRAPPER_H
 #define LIBDNF_WRAPPER_H
 
+#include <libdnf/libdnf.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <libdnf/libdnf.h>
 
 #define RETURN_VAL_STRUCT(struct_name, return_val)  \
 typedef struct {                                    \


### PR DESCRIPTION
libdnh.h includes C++ files. Having this include statement within the 'C' linkage block causes issues.
The PR moves this out of the 'C' linkage block.