### PR TITLE
Add Amazon Linux 2022 backend

### DIFF
--- a/rpm/dnf/dnf.go
+++ b/rpm/dnf/dnf.go
@@ -203,7 +203,7 @@ type ReplacerPair struct {
 }
 
 type ReplacerState struct {
-	pairs: ReplacerPair
+	pairs []ReplacerPair
 }
 
 func NewReplacerState() *ReplacerState {

--- a/rpm/dnf/dnf.go
+++ b/rpm/dnf/dnf.go
@@ -1,3 +1,4 @@
+//go:build dnf
 // +build dnf
 
 package dnf
@@ -295,7 +296,9 @@ func NewDnfBackend(release string, reposDir string, l types.Logger, target *type
 	reposDirC := C.CString(tmpDir)
 	defer C.free(unsafe.Pointer(reposDirC))
 
-	result := C.CreateAndSetupDNFContext(releaseC, reposDirC)
+	varsDirC := C.CString()
+
+	result := C.CreateAndSetupDNFContext(releaseC, reposDirC, varsDirC)
 	if result.err_msg != nil {
 		defer C.free(unsafe.Pointer(result.err_msg))
 		return nil, errors.New("error creating new dnf context: " + C.GoString(result.err_msg))

--- a/rpm/dnf/dnf.go
+++ b/rpm/dnf/dnf.go
@@ -228,10 +228,10 @@ func (s *ReplacerState) loadVarsFromDir(dir string) {
 	}
 }
 
-func (s *ReplacerState) stringReplacer() {
-	replacements := make([]string, 0, len(s.pairs) * 2)
-	for _, pair := s.pairs {
-		replacements = append(replacements, "$" + pair.varName, pair.value)
+func (s *ReplacerState) stringReplacer() *strings.Replacer {
+	replacements := make([]string, 0, len(s.pairs)*2)
+	for _, pair := range s.pairs {
+		replacements = append(replacements, "$"+pair.varName, pair.value)
 	}
 	return strings.NewReplacer(replacements...)
 }

--- a/rpm/dnf/dnf.go
+++ b/rpm/dnf/dnf.go
@@ -197,7 +197,7 @@ func (b *DnfBackend) GetEnabledRepositories() (repos []*Repository) {
 	return
 }
 
-type ReplacerPair {
+type ReplacerPair struct {
 	varName string
 	value string
 }

--- a/rpm/dnf/dnf.go
+++ b/rpm/dnf/dnf.go
@@ -199,7 +199,7 @@ func (b *DnfBackend) GetEnabledRepositories() (repos []*Repository) {
 
 type ReplacerPair struct {
 	varName string
-	value string
+	value   string
 }
 
 type ReplacerState struct {
@@ -221,7 +221,7 @@ func (s *ReplacerState) loadVarsFromDir(dir string) {
 			if content, err := os.ReadFile(filepath.Join(dir, filename)); err == nil {
 				s.pairs = append(s.pairs, ReplacerPair{
 					varName: filename,
-					value: strings.TrimSpace(string(content))
+					value:   strings.TrimSpace(string(content)),
 				})
 			}
 		}
@@ -231,19 +231,19 @@ func (s *ReplacerState) loadVarsFromDir(dir string) {
 func hostifyRepositories(reposDir string) (string, string, error) {
 	tmpDir, err := ioutil.TempDir("", "repos.d")
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	varsDir, err := ioutil.TempDir("", "vars")
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	logger.Infof("Scanning repo files in '%s'", reposDir)
 	repoFiles, err := filepath.Glob(reposDir + "/*.repo")
 	if err != nil {
 		os.RemoveAll(tmpDir)
-		return "", err
+		return "", "", err
 	}
 
 	replacerState := NewReplacerState()

--- a/rpm/dnf/libdnf_wrapper.cpp
+++ b/rpm/dnf/libdnf_wrapper.cpp
@@ -4,6 +4,7 @@
 #include <exception>
 #include <string>
 #include <string.h>
+#include <array>
 
 const char* newCString(std::string s) {
     size_t len = s.size()+1;
@@ -237,7 +238,7 @@ CreateAndSetupDNFContextResult CreateAndSetupDNFContext(const char* release, con
         }
 
         if (strlen(vars_dir) != 0) {
-            const char*[1] vars_dir_array = {vars_dir, nullptr};
+            std::array<const char*, 2> vars_dir_array = {vars_dir, nullptr};
             dnf_context_set_vars_dir(context, vars_dir_array);
         }
         dnf_context_set_install_root(context, install_root);

--- a/rpm/dnf/libdnf_wrapper.cpp
+++ b/rpm/dnf/libdnf_wrapper.cpp
@@ -235,8 +235,10 @@ CreateAndSetupDNFContextResult CreateAndSetupDNFContext(const char* release, con
         if (strlen(repos_dir) != 0) {
             dnf_context_set_repo_dir(context, repos_dir);
         }
+
         if (strlen(vars_dir) != 0) {
-            dnf_context_set_vars_dir(context, vars_dir);
+            const char*[1] vars_dir_array = {vars_dir, 0};
+            dnf_context_set_vars_dir(context, vars_dir_array);
         }
         dnf_context_set_install_root(context, install_root);
 

--- a/rpm/dnf/libdnf_wrapper.cpp
+++ b/rpm/dnf/libdnf_wrapper.cpp
@@ -217,7 +217,7 @@ bool GetRepositories(DnfContext* context, DnfRepo** repos_out, int repos_out_siz
     return true;
 }
 
-CreateAndSetupDNFContextResult CreateAndSetupDNFContext(const char* release, const char* repos_dir) {
+CreateAndSetupDNFContextResult CreateAndSetupDNFContext(const char* release, const char* repos_dir, const char* vars_dir) {
     CreateAndSetupDNFContextResult result = {0};
     try {
         DnfContext* context = dnf_context_new();
@@ -234,6 +234,9 @@ CreateAndSetupDNFContextResult CreateAndSetupDNFContext(const char* release, con
         dnf_context_set_cache_dir(context, cache_dir);
         if (strlen(repos_dir) != 0) {
             dnf_context_set_repo_dir(context, repos_dir);
+        }
+        if (strlen(vars_dir) != 0) {
+            dnf_context_set_vars_dir(context, vars_dir);
         }
         dnf_context_set_install_root(context, install_root);
 

--- a/rpm/dnf/libdnf_wrapper.cpp
+++ b/rpm/dnf/libdnf_wrapper.cpp
@@ -237,7 +237,7 @@ CreateAndSetupDNFContextResult CreateAndSetupDNFContext(const char* release, con
         }
 
         if (strlen(vars_dir) != 0) {
-            const char*[1] vars_dir_array = {vars_dir, 0};
+            const char*[1] vars_dir_array = {vars_dir, nullptr};
             dnf_context_set_vars_dir(context, vars_dir_array);
         }
         dnf_context_set_install_root(context, install_root);

--- a/rpm/dnf/libdnf_wrapper.cpp
+++ b/rpm/dnf/libdnf_wrapper.cpp
@@ -239,7 +239,7 @@ CreateAndSetupDNFContextResult CreateAndSetupDNFContext(const char* release, con
 
         if (strlen(vars_dir) != 0) {
             std::array<const char*, 2> vars_dir_array = {vars_dir, nullptr};
-            dnf_context_set_vars_dir(context, vars_dir_array);
+            dnf_context_set_vars_dir(context, vars_dir_array.data());
         }
         dnf_context_set_install_root(context, install_root);
 

--- a/rpm/dnf/libdnf_wrapper.h
+++ b/rpm/dnf/libdnf_wrapper.h
@@ -61,7 +61,7 @@ See https://golang.org/cmd/cgo/#hdr-Passing_pointers for more information.
 bool GetRepositories(DnfContext* context, DnfRepo** repos_out, int repos_out_size);
 
 RETURN_VAL_STRUCT(CreateAndSetupDNFContextResult, DnfContext* context);
-CreateAndSetupDNFContextResult CreateAndSetupDNFContext(const char* release, const char* repos_dir);
+CreateAndSetupDNFContextResult CreateAndSetupDNFContext(const char* release, const char* repos_dir, const char* vars_dir);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Amazon linux 2022 is based on fedora and not RHEL. Moreover this backend needs to add a GPG key like the fedora one thus the re-using of the functionality here.