### PR TITLE
Increase CircleCI timeout for molecule tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,6 +135,7 @@ commands:
     steps:
       - run:
           name: Run molecule tests
+          no_output_timeout: 30m
           command: |
             source venv/bin/activate
             cd tests


### PR DESCRIPTION
Some tests are a bit slow to download VMs, and may timeout