### PR TITLE
Add Amazon Linux 2022 dnf based backend

### DIFF
--- a/rpm/amazonlinux.go
+++ b/rpm/amazonlinux.go
@@ -10,21 +10,6 @@ import (
 	"github.com/DataDog/nikos/types"
 )
 
-type AmazonLinux2022Backend struct {
-	dnfBackend *dnf.DnfBackend
-	logger     types.Logger
-	target     *types.Target
-}
-
-func (b *AmazonLinux2022Backend) GetKernelHeaders(directory string) error {
-	pkgNevra := "kernel-devel"
-	return b.dnfBackend.GetKernelHeaders(pkgNevra, directory)
-}
-
-func (b *AmazonLinux2022Backend) Close() {
-	b.dnfBackend.Close()
-}
-
 func NewAmazonLinux2022Backend(target *types.Target, reposDir string, logger types.Logger) (*RedHatBackend, error) {
 	releaseVer, err := extractReleaseVersionFromImageID()
 	if err != nil {

--- a/rpm/amazonlinux.go
+++ b/rpm/amazonlinux.go
@@ -1,0 +1,67 @@
+package rpm
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"regexp"
+
+	"github.com/DataDog/nikos/rpm/dnf"
+	"github.com/DataDog/nikos/types"
+)
+
+type AmazonLinux2022Backend struct {
+	dnfBackend *dnf.DnfBackend
+	logger     types.Logger
+	target     *types.Target
+}
+
+func (b *AmazonLinux2022Backend) GetKernelHeaders(directory string) error {
+	pkgNevra := "kernel-devel"
+	return b.dnfBackend.GetKernelHeaders(pkgNevra, directory)
+}
+
+func (b *AmazonLinux2022Backend) Close() {
+	b.dnfBackend.Close()
+}
+
+func NewAmazonLinux2022Backend(target *types.Target, reposDir string, logger types.Logger) (*RedHatBackend, error) {
+	releaseVer, err := extractReleaseVersionFromImageID()
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract release version: %w", err)
+	}
+
+	dnfBackend, err := dnf.NewDnfBackend(releaseVer, reposDir, logger, target)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create DNF backend: %w", err)
+	}
+
+	return &RedHatBackend{
+		target:     target,
+		logger:     logger,
+		dnfBackend: dnfBackend,
+	}, nil
+}
+
+var imageFilePattern = regexp.MustCompile(`image_file="al2022-\w+-(2022.0.\d{8}).*"`)
+
+func extractReleaseVersionFromImageID() (string, error) {
+	imageIDPath := types.HostEtc("image-id")
+	f, err := os.Open(imageIDPath)
+	if err != nil {
+		return "", err
+	}
+
+	liner := bufio.NewScanner(f)
+	for liner.Scan() {
+		if submatches := imageFilePattern.FindStringSubmatch(liner.Text()); submatches != nil {
+			return submatches[1], nil
+		}
+	}
+
+	if err := liner.Err(); err != nil {
+		return "", err
+	}
+
+	return "", fmt.Errorf("image_file entry not found in %s", imageIDPath)
+}


### PR DESCRIPTION
The main issue with Amazon Linux 2022 is to collect the `releasever` variable. The source of truth is of course the version field returned by `rpm -qi system-release`.

This PR uses the content of `/etc/image-id` to compute this `releasever`.

Content from a standard al2022 container:
```
image_name="al2022-container"
image_version="2022"
image_arch="aarch64"
image_file="al2022-container-2022.0.20220928.0-arm64"
image_stamp="9d26-a211"
image_date="20220929205755"
recipe_name="al2022 container"
recipe_id="aebe3f02-8765-8be4-ae2e-3498-51a8-207e-5201732d"
```
What we are interested in is the `2022.0.20220928` in the `image_file` line.
An ami based deployment will have `al2022-ami-$releasever.0-xxxxx` so it matches the regexp as well.

This PR was tested against an agent build

N.B: we cannot add tests for amazon linux for now since all vagrant boxes available online are based on virtualbox, this will be added in a future PR