### PR TITLE
fix centos docker install

### DIFF
--- a/tests/molecule/centos-container/prepare.yml
+++ b/tests/molecule/centos-container/prepare.yml
@@ -17,20 +17,15 @@
       become: true
 
     - name: Install Docker
-      package:
-        name: "{{ item }}"
-      with_items:
-        - libseccomp
-        - docker-ce
-        - docker-ce-cli
-        - containerd.io
-        - docker-buildx-plugin
-        - docker-compose-plugin
-      become: true
-
-    - name: Install pip
-      package:
-        name: python3-pip
+      yum:
+        name:
+          - libseccomp
+          - docker-ce
+          - docker-ce-cli
+          - containerd.io
+          - docker-buildx-plugin
+          - docker-compose-plugin
+          - python3-pip
       become: true
 
     - name: Install docker-py

--- a/tests/molecule/centos-container/prepare.yml
+++ b/tests/molecule/centos-container/prepare.yml
@@ -2,76 +2,61 @@
 - name: Prepare
   hosts: all
   tasks:
-  - name: Disable SElinux
-    shell: setenforce 0
-    become: true
+    - name: Disable SElinux
+      shell: setenforce 0
+      become: true
 
-  - name: Install Docker
-    package:
-      name: "{{ item }}"
-    become: true
-    with_items:
-    - docker
-    - python-requests
-    - python-docker
-    when: ansible_distribution_major_version == '7'
+    - name: Set up Docker repository
+      shell: yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+      become: true
 
-  - name: Set up Docker repository
-    shell: yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
-    become: true
-    when: ansible_distribution_major_version > '7'
+    - name: Find all repo files
+      find:
+        paths: /etc/yum.repos.d/
+        patterns: "CentOS*.repo"
+      become: true
+      register: repos
 
-  - name: Find all repo files
-    find:
-      paths: /etc/yum.repos.d/
-      patterns: "CentOS*.repo"
-    become: true
-    register: repos
-    when: ansible_distribution_major_version > '7'
+    - name: Comment out mirrorlists
+      replace:
+        path: "{{ item.path }}"
+        regexp: "mirrorlist"
+        replace: "#mirrorlist"
+      become: true
+      with_items: "{{ repos.files }}"
 
-  - name: Comment out mirrorlists
-    replace:
-      path: "{{ item.path }}"
-      regexp: 'mirrorlist'
-      replace: '#mirrorlist'
-    become: true
-    with_items: "{{ repos.files }}"
-    when: ansible_distribution_major_version > '7'
+    - name: Use vault instead of mirror
+      replace:
+        path: "{{ item.path }}"
+        regexp: "#baseurl=http://mirror.centos.org"
+        replace: "baseurl=http://vault.centos.org"
+      become: true
+      with_items: "{{ repos.files }}"
 
-  - name: Use vault instead of mirror
-    replace:
-      path: "{{ item.path }}"
-      regexp: '#baseurl=http://mirror.centos.org'
-      replace: 'baseurl=http://vault.centos.org'
-    become: true
-    with_items: "{{ repos.files }}"
-    when: ansible_distribution_major_version > '7'
+    - name: Install Docker
+      package:
+        name: "{{ item }}"
+        state: latest
+      with_items:
+        - libseccomp
+        - docker-ce
+        - docker-ce-cli
+        - containerd.io
+        - docker-buildx-plugin
+        - docker-compose-plugin
+      become: true
 
-  - name: Install Docker
-    package:
-      name: "{{ item }}"
-      state: latest
-    with_items:
-    - docker-ce
-    - docker-ce-cli
-    - containerd.io
-    - libseccomp
-    become: true
-    when: ansible_distribution_major_version > '7'
+    - name: Install pip
+      package:
+        name: python3-pip
+      become: true
 
-  - name: Install pip
-    package:
-      name: python3-pip
-    become: true
-    when: ansible_distribution_major_version > '7'
+    - name: Install docker-py
+      shell: "pip3 install docker"
+      become: true
 
-  - name: Install docker-py
-    shell: 'pip3 install docker'
-    become: true
-    when: ansible_distribution_major_version > '7'
-
-  - name: Start docker
-    service:
-      name: docker
-      state: started
-    become: true
+    - name: Start docker
+      service:
+        name: docker
+        state: started
+      become: true

--- a/tests/molecule/centos-container/prepare.yml
+++ b/tests/molecule/centos-container/prepare.yml
@@ -10,6 +10,7 @@
       get_url:
         url: https://download.docker.com/linux/centos/docker-ce.repo
         dest: /etc/yum.repos.d/docker-ce.repo
+      become: true
 
     - name: Refresh cache
       shell: yum clean expire-cache

--- a/tests/molecule/centos-container/prepare.yml
+++ b/tests/molecule/centos-container/prepare.yml
@@ -7,13 +7,17 @@
       become: true
 
     - name: Set up Docker repository
-      shell: yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+      get_url:
+        url: https://download.docker.com/linux/centos/docker-ce.repo
+        dest: /etc/yum.repos.d/docker-ce.repo
+
+    - name: Refresh cache
+      shell: yum clean expire-cache
       become: true
 
     - name: Install Docker
       package:
         name: "{{ item }}"
-        state: latest
       with_items:
         - libseccomp
         - docker-ce

--- a/tests/molecule/centos-container/prepare.yml
+++ b/tests/molecule/centos-container/prepare.yml
@@ -12,6 +12,32 @@
         dest: /etc/yum.repos.d/docker-ce.repo
       become: true
 
+    - name: Find all repo files
+      find:
+        paths: /etc/yum.repos.d/
+        patterns: "CentOS*.repo"
+      become: true
+      register: repos
+      when: ansible_distribution_major_version > '7'
+
+    - name: Comment out mirrorlists
+      replace:
+        path: "{{ item.path }}"
+        regexp: "mirrorlist"
+        replace: "#mirrorlist"
+      become: true
+      with_items: "{{ repos.files }}"
+      when: ansible_distribution_major_version > '7'
+
+    - name: Use vault instead of mirror
+      replace:
+        path: "{{ item.path }}"
+        regexp: "#baseurl=http://mirror.centos.org"
+        replace: "baseurl=http://vault.centos.org"
+      become: true
+      with_items: "{{ repos.files }}"
+      when: ansible_distribution_major_version > '7'
+
     - name: Refresh cache
       shell: yum clean expire-cache
       become: true
@@ -27,6 +53,12 @@
           - docker-compose-plugin
       become: true
 
+    - name: Install Docker
+      package:
+        name: python-docker
+      become: true
+      when: ansible_distribution_major_version == '7'
+
     - name: Install pip
       package:
         name: python3-pip
@@ -36,6 +68,7 @@
     - name: Install docker-py
       shell: "pip3 install docker"
       become: true
+      when: ansible_distribution_major_version > '7'
 
     - name: Start docker
       service:

--- a/tests/molecule/centos-container/prepare.yml
+++ b/tests/molecule/centos-container/prepare.yml
@@ -49,8 +49,6 @@
           - docker-ce
           - docker-ce-cli
           - containerd.io
-          - docker-buildx-plugin
-          - docker-compose-plugin
       become: true
 
     - name: Install Docker

--- a/tests/molecule/centos-container/prepare.yml
+++ b/tests/molecule/centos-container/prepare.yml
@@ -10,29 +10,6 @@
       shell: yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
       become: true
 
-    - name: Find all repo files
-      find:
-        paths: /etc/yum.repos.d/
-        patterns: "CentOS*.repo"
-      become: true
-      register: repos
-
-    - name: Comment out mirrorlists
-      replace:
-        path: "{{ item.path }}"
-        regexp: "mirrorlist"
-        replace: "#mirrorlist"
-      become: true
-      with_items: "{{ repos.files }}"
-
-    - name: Use vault instead of mirror
-      replace:
-        path: "{{ item.path }}"
-        regexp: "#baseurl=http://mirror.centos.org"
-        replace: "baseurl=http://vault.centos.org"
-      become: true
-      with_items: "{{ repos.files }}"
-
     - name: Install Docker
       package:
         name: "{{ item }}"

--- a/tests/molecule/centos-container/prepare.yml
+++ b/tests/molecule/centos-container/prepare.yml
@@ -45,6 +45,7 @@
           - docker-ce
           - docker-ce-cli
           - containerd.io
+        state: latest
       become: true
 
     - name: Install Docker

--- a/tests/molecule/centos-container/prepare.yml
+++ b/tests/molecule/centos-container/prepare.yml
@@ -25,8 +25,13 @@
           - containerd.io
           - docker-buildx-plugin
           - docker-compose-plugin
-          - python3-pip
       become: true
+
+    - name: Install pip
+      package:
+        name: python3-pip
+      become: true
+      when: ansible_distribution_major_version > '7'
 
     - name: Install docker-py
       shell: "pip3 install docker"

--- a/tests/molecule/centos-container/prepare.yml
+++ b/tests/molecule/centos-container/prepare.yml
@@ -38,10 +38,6 @@
       with_items: "{{ repos.files }}"
       when: ansible_distribution_major_version > '7'
 
-    - name: Refresh cache
-      shell: yum clean expire-cache
-      become: true
-
     - name: Install Docker
       yum:
         name:


### PR DESCRIPTION
This PR fixes the docker install method in `centos-container` tests to use a more recent version of docker. This will allow this test entry to pull recent images.