### PR TITLE
add specific Oracle backend for specific UEK support

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -72,7 +72,7 @@ var DownloadCmd = &cobra.Command{
 			case "centos":
 				backend, err = rpm.NewCentOSBackend(&target, rpmReposDir, logger)
 			case "oracle", "ol":
-				backend, err = rpm.NewRedHatBackend(&target, rpmReposDir, logger)
+				backend, err = rpm.NewOracleBackend(&target, rpmReposDir, logger)
 			case "amazon":
 				if target.Distro.Release == "2022" {
 					backend, err = rpm.NewAmazonLinux2022Backend(&target, rpmReposDir, logger)

--- a/rpm/oracle.go
+++ b/rpm/oracle.go
@@ -1,0 +1,59 @@
+package rpm
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/DataDog/nikos/rpm/dnfv2"
+	"github.com/DataDog/nikos/rpm/dnfv2/backend"
+	"github.com/DataDog/nikos/types"
+)
+
+type OracleBackend struct {
+	dnfBackend *backend.Backend
+	logger     types.Logger
+	target     *types.Target
+}
+
+func (b *OracleBackend) GetKernelHeaders(directory string) error {
+	for _, targetPackageName := range []string{"kernel-devel", "kernel-uek-devel"} {
+		pkgMatcher := dnfv2.DefaultPkgMatcher(targetPackageName, b.target.Uname.Kernel)
+
+		pkg, data, err := b.dnfBackend.FetchPackage(pkgMatcher)
+		if err != nil {
+			b.logger.Errorf("failed to fetch `%s` package: %v", targetPackageName, err)
+			continue
+		}
+
+		return dnfv2.ExtractPackage(pkg, data, directory, b.target, b.logger)
+	}
+
+	return fmt.Errorf("failed to find a valid package")
+}
+
+func (b *OracleBackend) Close() {
+}
+
+func NewOracleBackend(target *types.Target, reposDir string, logger types.Logger) (*RedHatBackend, error) {
+	b, err := dnfv2.NewBackend(target.Distro.Release, reposDir)
+	if err != nil {
+		return nil, err
+	}
+
+	uekRepoPattern := regexp.MustCompile(`^ol\d_UEK.*`)
+
+	// force enable UEK repos
+	for i := range b.Repositories {
+		repo := &b.Repositories[i]
+
+		if uekRepoPattern.MatchString(repo.Name) {
+			repo.Enabled = true
+		}
+	}
+
+	return &RedHatBackend{
+		target:     target,
+		logger:     logger,
+		dnfBackend: b,
+	}, nil
+}

--- a/rpm/oracle.go
+++ b/rpm/oracle.go
@@ -34,7 +34,7 @@ func (b *OracleBackend) GetKernelHeaders(directory string) error {
 func (b *OracleBackend) Close() {
 }
 
-func NewOracleBackend(target *types.Target, reposDir string, logger types.Logger) (*RedHatBackend, error) {
+func NewOracleBackend(target *types.Target, reposDir string, logger types.Logger) (*OracleBackend, error) {
 	b, err := dnfv2.NewBackend(target.Distro.Release, reposDir)
 	if err != nil {
 		return nil, err
@@ -51,7 +51,7 @@ func NewOracleBackend(target *types.Target, reposDir string, logger types.Logger
 		}
 	}
 
-	return &RedHatBackend{
+	return &OracleBackend{
 		target:     target,
 		logger:     logger,
 		dnfBackend: b,


### PR DESCRIPTION
This PR adds a new backend specific to Oracle, similar to the redhat one, with the goal of supporting Oracle with UEK kernels. They need a specific repo to be enabled (the repo is disabled by default for example in the default docker image), and the package has a different name (`kernel-uek-devel`).