### PR TITLE
fix molecule ci

### DIFF
--- a/.ci_build/requirements.txt
+++ b/.ci_build/requirements.txt
@@ -1,4 +1,4 @@
-ansible
-molecule
-molecule-vagrant
-python-vagrant
+ansible==7.4.0
+molecule==4.0.4
+molecule-vagrant==2.0.0
+python-vagrant==1.0.0

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,8 +5,8 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 100
-  - package-ecosystem: "pip"
-    directory: "/.ci_build"
+  - package-ecosystem: pip
+    directory: /.ci_build
     schedule:
-      interval: "monthly"
+      interval: monthly
     open-pull-requests-limit: 100

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,3 +5,8 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 100
+  - package-ecosystem: "pip"
+    directory: "/.ci_build"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 100


### PR DESCRIPTION
Molecule 5.0.0 breaks the CI. This PR fixes the issue by freezing all versions to working one, and enables dependabot to stay up to date.