### PR TITLE
Fix molecule stacktrace in CI

### DIFF
--- a/.ci_build/requirements.txt
+++ b/.ci_build/requirements.txt
@@ -2,3 +2,4 @@ ansible==7.5.0
 molecule==4.0.4
 molecule-vagrant==2.0.0
 python-vagrant==1.0.0
+ansible-compat<4 # https://github.com/ansible-community/molecule/issues/3903


### PR DESCRIPTION
There is a bug related to the recent released version of `ansible_compat` v4.0.1 (see https://github.com/ansible-community/molecule/issues/3903 for more details). This PR pin the version of this package to <4.