### PR TITLE
bump golang to 1.20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: "1.20"
 
       - name: Cache Go modules
         uses: actions/cache@v3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/nikos
 
-go 1.18
+go 1.20
 
 require (
 	cloud.google.com/go/storage v1.33.0


### PR DESCRIPTION
some of our dependencies are starting to require more recent golang versions ([example](https://github.com/DataDog/nikos/pull/198)). This PR bumps the required golang version to 1.20 (the same as the one used by the agent and the oldest officially supported golang version)