### PR TITLE
CI: macos-13 + manual install of vagrant and virtualbox

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
   molecule-tests:
     name: Molecule tests
     needs: build
-    runs-on: macos-12
+    runs-on: macos-13
     strategy:
       fail-fast: false
       matrix:
@@ -75,6 +75,11 @@ jobs:
           ]
         test_type: ["host", "container"]
     steps:
+      - name: Install vagrant
+        run: |
+          brew install --cask virtualbox
+          brew install --cask vagrant
+
       - name: Checkout source code
         uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,3 +118,8 @@ jobs:
       - name: Run molecule test
         working-directory: tests
         run: molecule test -s ${{ matrix.platform }}-${{ matrix.test_type }}
+
+      - name: Print vagrant error
+        if: failure()
+        run: |
+          cat /Users/runner/.cache/molecule/tests/centos-host/vagrant.err

--- a/tests/molecule/amazon-linux-container/molecule.yml
+++ b/tests/molecule/amazon-linux-container/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: amzn2
     box: gbailey/amzn2
-    memory: 512
+    memory: 1024
     cpus: 1
 provisioner:
   name: ansible

--- a/tests/molecule/amazon-linux-container/molecule.yml
+++ b/tests/molecule/amazon-linux-container/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: amzn2
     box: gbailey/amzn2
-    memory: 1024
+    memory: 256
     cpus: 1
 provisioner:
   name: ansible

--- a/tests/molecule/amazon-linux-host/molecule.yml
+++ b/tests/molecule/amazon-linux-host/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: amzn2
     box: gbailey/amzn2
-    memory: 512
+    memory: 1024
     cpus: 1
 provisioner:
   name: ansible

--- a/tests/molecule/amazon-linux-host/molecule.yml
+++ b/tests/molecule/amazon-linux-host/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: amzn2
     box: gbailey/amzn2
-    memory: 1024
+    memory: 256
     cpus: 1
 provisioner:
   name: ansible

--- a/tests/molecule/centos-container/molecule.yml
+++ b/tests/molecule/centos-container/molecule.yml
@@ -7,17 +7,17 @@ platforms:
   - name: centos7.1804.02
     box: centos/7
     box_version: 1804.02
-    memory: 1024
+    memory: 256
     cpus: 1
   - name: centos7.1905.1
     box: centos/7
     box_version: 1905.1
-    memory: 1024
+    memory: 256
     cpus: 1
   - name: centos8.1905.1
     box: centos/8
     box_version: 1905.1
-    memory: 1024
+    memory: 256
     cpus: 1
 provisioner:
   name: ansible

--- a/tests/molecule/centos-container/molecule.yml
+++ b/tests/molecule/centos-container/molecule.yml
@@ -7,22 +7,22 @@ platforms:
   - name: centos7.1804.02
     box: centos/7
     box_version: 1804.02
-    memory: 512
+    memory: 1024
     cpus: 1
   - name: centos7.1905.1
     box: centos/7
     box_version: 1905.1
-    memory: 512
+    memory: 1024
     cpus: 1
   - name: centos8.1905.1
     box: centos/8
     box_version: 1905.1
-    memory: 512
+    memory: 1024
     cpus: 1
 provisioner:
   name: ansible
   env:
-    TEST_TYPE: 'container'
+    TEST_TYPE: "container"
     NIKOS_PREFIX: sudo docker exec -ti debian
   playbooks:
     converge: ../resources/playbooks/converge.yml

--- a/tests/molecule/centos-host/molecule.yml
+++ b/tests/molecule/centos-host/molecule.yml
@@ -7,17 +7,17 @@ platforms:
   - name: centos7.1804.02
     box: centos/7
     box_version: 1804.02
-    memory: 1024
+    memory: 256
     cpus: 1
   - name: centos7.1905.1
     box: centos/7
     box_version: 1905.1
-    memory: 1024
+    memory: 256
     cpus: 1
   - name: centos8.1905.1
     box: centos/8
     box_version: 1905.1
-    memory: 1024
+    memory: 256
     cpus: 1
 provisioner:
   name: ansible

--- a/tests/molecule/centos-host/molecule.yml
+++ b/tests/molecule/centos-host/molecule.yml
@@ -7,22 +7,22 @@ platforms:
   - name: centos7.1804.02
     box: centos/7
     box_version: 1804.02
-    memory: 512
+    memory: 1024
     cpus: 1
   - name: centos7.1905.1
     box: centos/7
     box_version: 1905.1
-    memory: 512
+    memory: 1024
     cpus: 1
   - name: centos8.1905.1
     box: centos/8
     box_version: 1905.1
-    memory: 512
+    memory: 1024
     cpus: 1
 provisioner:
   name: ansible
   env:
-    TEST_TYPE: 'host'
+    TEST_TYPE: "host"
   playbooks:
     converge: ../resources/playbooks/converge.yml
     verify: ../resources/playbooks/verify.yml

--- a/tests/molecule/debian-container/molecule.yml
+++ b/tests/molecule/debian-container/molecule.yml
@@ -6,16 +6,16 @@ driver:
 platforms:
   - name: debian9
     box: roboxes/debian9
-    memory: 512
+    memory: 1024
     cpus: 1
   - name: debian10
     box: roboxes/debian10
-    memory: 512
+    memory: 1024
     cpus: 1
 provisioner:
   name: ansible
   env:
-    TEST_TYPE: 'container'
+    TEST_TYPE: "container"
     NIKOS_PREFIX: sudo docker exec -ti debian
   playbooks:
     converge: ../resources/playbooks/converge.yml

--- a/tests/molecule/debian-container/molecule.yml
+++ b/tests/molecule/debian-container/molecule.yml
@@ -6,11 +6,11 @@ driver:
 platforms:
   - name: debian9
     box: roboxes/debian9
-    memory: 1024
+    memory: 256
     cpus: 1
   - name: debian10
     box: roboxes/debian10
-    memory: 1024
+    memory: 256
     cpus: 1
 provisioner:
   name: ansible

--- a/tests/molecule/debian-host/molecule.yml
+++ b/tests/molecule/debian-host/molecule.yml
@@ -6,11 +6,11 @@ driver:
 platforms:
   - name: debian9
     box: roboxes/debian9
-    memory: 1024
+    memory: 256
     cpus: 1
   - name: debian10
     box: roboxes/debian10
-    memory: 1024
+    memory: 256
     cpus: 1
 provisioner:
   name: ansible

--- a/tests/molecule/debian-host/molecule.yml
+++ b/tests/molecule/debian-host/molecule.yml
@@ -6,11 +6,11 @@ driver:
 platforms:
   - name: debian9
     box: roboxes/debian9
-    memory: 512
+    memory: 1024
     cpus: 1
   - name: debian10
     box: roboxes/debian10
-    memory: 512
+    memory: 1024
     cpus: 1
 provisioner:
   name: ansible

--- a/tests/molecule/fedora-container/molecule.yml
+++ b/tests/molecule/fedora-container/molecule.yml
@@ -6,20 +6,20 @@ driver:
 platforms:
   - name: fedora32
     box: generic/fedora32
-    memory: 512
+    memory: 1024
     cpus: 1
   - name: fedora33
     box: generic/fedora33
-    memory: 512
+    memory: 1024
     cpus: 1
   - name: fedora34
     box: generic/fedora34
-    memory: 512
+    memory: 1024
     cpus: 1
 provisioner:
   name: ansible
   env:
-    TEST_TYPE: 'container'
+    TEST_TYPE: "container"
     NIKOS_PREFIX: sudo docker exec -ti debian
   playbooks:
     converge: ../resources/playbooks/converge.yml

--- a/tests/molecule/fedora-container/molecule.yml
+++ b/tests/molecule/fedora-container/molecule.yml
@@ -6,15 +6,15 @@ driver:
 platforms:
   - name: fedora32
     box: generic/fedora32
-    memory: 1024
+    memory: 256
     cpus: 1
   - name: fedora33
     box: generic/fedora33
-    memory: 1024
+    memory: 256
     cpus: 1
   - name: fedora34
     box: generic/fedora34
-    memory: 1024
+    memory: 256
     cpus: 1
 provisioner:
   name: ansible

--- a/tests/molecule/fedora-host/molecule.yml
+++ b/tests/molecule/fedora-host/molecule.yml
@@ -6,20 +6,20 @@ driver:
 platforms:
   - name: fedora32
     box: generic/fedora32
-    memory: 512
+    memory: 1024
     cpus: 1
   - name: fedora33
     box: generic/fedora33
-    memory: 512
+    memory: 1024
     cpus: 1
   - name: fedora34
     box: generic/fedora34
-    memory: 512
+    memory: 1024
     cpus: 1
 provisioner:
   name: ansible
   env:
-    TEST_TYPE: 'host'
+    TEST_TYPE: "host"
   playbooks:
     converge: ../resources/playbooks/converge.yml
     verify: ../resources/playbooks/verify.yml

--- a/tests/molecule/fedora-host/molecule.yml
+++ b/tests/molecule/fedora-host/molecule.yml
@@ -6,15 +6,15 @@ driver:
 platforms:
   - name: fedora32
     box: generic/fedora32
-    memory: 1024
+    memory: 256
     cpus: 1
   - name: fedora33
     box: generic/fedora33
-    memory: 1024
+    memory: 256
     cpus: 1
   - name: fedora34
     box: generic/fedora34
-    memory: 1024
+    memory: 256
     cpus: 1
 provisioner:
   name: ansible

--- a/tests/molecule/opensuse-container/molecule.yml
+++ b/tests/molecule/opensuse-container/molecule.yml
@@ -6,16 +6,16 @@ driver:
 platforms:
   - name: opensuse15
     box: roboxes/opensuse15
-    memory: 512
+    memory: 1024
     cpus: 1
   - name: opensuse42
     box: generic/opensuse42
-    memory: 512
+    memory: 1024
     cpus: 1
 provisioner:
   name: ansible
   env:
-    TEST_TYPE: 'container'
+    TEST_TYPE: "container"
     NIKOS_PREFIX: sudo docker exec -ti debian
   playbooks:
     converge: ../resources/playbooks/converge.yml

--- a/tests/molecule/opensuse-container/molecule.yml
+++ b/tests/molecule/opensuse-container/molecule.yml
@@ -6,11 +6,11 @@ driver:
 platforms:
   - name: opensuse15
     box: roboxes/opensuse15
-    memory: 1024
+    memory: 256
     cpus: 1
   - name: opensuse42
     box: generic/opensuse42
-    memory: 1024
+    memory: 256
     cpus: 1
 provisioner:
   name: ansible

--- a/tests/molecule/opensuse-host/molecule.yml
+++ b/tests/molecule/opensuse-host/molecule.yml
@@ -6,16 +6,16 @@ driver:
 platforms:
   - name: opensuse15
     box: roboxes/opensuse15
-    memory: 512
+    memory: 1024
     cpus: 1
   - name: opensuse42
     box: generic/opensuse42
-    memory: 512
+    memory: 1024
     cpus: 1
 provisioner:
   name: ansible
   env:
-    TEST_TYPE: 'host'
+    TEST_TYPE: "host"
   playbooks:
     converge: ../resources/playbooks/converge.yml
     verify: ../resources/playbooks/verify.yml

--- a/tests/molecule/opensuse-host/molecule.yml
+++ b/tests/molecule/opensuse-host/molecule.yml
@@ -6,11 +6,11 @@ driver:
 platforms:
   - name: opensuse15
     box: roboxes/opensuse15
-    memory: 1024
+    memory: 256
     cpus: 1
   - name: opensuse42
     box: generic/opensuse42
-    memory: 1024
+    memory: 256
     cpus: 1
 provisioner:
   name: ansible

--- a/tests/molecule/oracle-container/molecule.yml
+++ b/tests/molecule/oracle-container/molecule.yml
@@ -8,12 +8,12 @@ driver:
 platforms:
   - name: oracle7
     box: generic/oracle7
-    memory: 512
+    memory: 1024
     cpus: 1
 provisioner:
   name: ansible
   env:
-    TEST_TYPE: 'container'
+    TEST_TYPE: "container"
     NIKOS_PREFIX: sudo docker exec -ti debian
   playbooks:
     converge: ../resources/playbooks/converge.yml

--- a/tests/molecule/oracle-container/molecule.yml
+++ b/tests/molecule/oracle-container/molecule.yml
@@ -8,7 +8,7 @@ driver:
 platforms:
   - name: oracle7
     box: generic/oracle7
-    memory: 1024
+    memory: 256
     cpus: 1
 provisioner:
   name: ansible

--- a/tests/molecule/oracle-host/molecule.yml
+++ b/tests/molecule/oracle-host/molecule.yml
@@ -8,12 +8,12 @@ driver:
 platforms:
   - name: oracle7
     box: generic/oracle7
-    memory: 512
+    memory: 1024
     cpus: 1
 provisioner:
   name: ansible
   env:
-    TEST_TYPE: 'host'
+    TEST_TYPE: "host"
   playbooks:
     converge: ../resources/playbooks/converge.yml
     verify: ../resources/playbooks/verify.yml

--- a/tests/molecule/oracle-host/molecule.yml
+++ b/tests/molecule/oracle-host/molecule.yml
@@ -8,7 +8,7 @@ driver:
 platforms:
   - name: oracle7
     box: generic/oracle7
-    memory: 1024
+    memory: 256
     cpus: 1
 provisioner:
   name: ansible

--- a/tests/molecule/ubuntu-container/molecule.yml
+++ b/tests/molecule/ubuntu-container/molecule.yml
@@ -6,20 +6,20 @@ driver:
 platforms:
   - name: ubuntu1604
     box: roboxes/ubuntu1604
-    memory: 512
+    memory: 1024
     cpus: 1
   - name: ubuntu1804
     box: roboxes/ubuntu1804
-    memory: 512
+    memory: 1024
     cpus: 1
   - name: ubuntu2004
     box: roboxes/ubuntu2004
-    memory: 512
+    memory: 1024
     cpus: 1
 provisioner:
   name: ansible
   env:
-    TEST_TYPE: 'container'
+    TEST_TYPE: "container"
     NIKOS_PREFIX: sudo docker exec -ti debian
   playbooks:
     converge: ../resources/playbooks/converge.yml

--- a/tests/molecule/ubuntu-container/molecule.yml
+++ b/tests/molecule/ubuntu-container/molecule.yml
@@ -6,15 +6,15 @@ driver:
 platforms:
   - name: ubuntu1604
     box: roboxes/ubuntu1604
-    memory: 1024
+    memory: 256
     cpus: 1
   - name: ubuntu1804
     box: roboxes/ubuntu1804
-    memory: 1024
+    memory: 256
     cpus: 1
   - name: ubuntu2004
     box: roboxes/ubuntu2004
-    memory: 1024
+    memory: 256
     cpus: 1
 provisioner:
   name: ansible

--- a/tests/molecule/ubuntu-host/molecule.yml
+++ b/tests/molecule/ubuntu-host/molecule.yml
@@ -6,20 +6,20 @@ driver:
 platforms:
   - name: ubuntu1604
     box: roboxes/ubuntu1604
-    memory: 512
+    memory: 1024
     cpus: 1
   - name: ubuntu1804
     box: roboxes/ubuntu1804
-    memory: 512
+    memory: 1024
     cpus: 1
   - name: ubuntu2004
     box: roboxes/ubuntu2004
-    memory: 512
+    memory: 1024
     cpus: 1
 provisioner:
   name: ansible
   env:
-    TEST_TYPE: 'host'
+    TEST_TYPE: "host"
   playbooks:
     converge: ../resources/playbooks/converge.yml
     verify: ../resources/playbooks/verify.yml

--- a/tests/molecule/ubuntu-host/molecule.yml
+++ b/tests/molecule/ubuntu-host/molecule.yml
@@ -6,15 +6,15 @@ driver:
 platforms:
   - name: ubuntu1604
     box: roboxes/ubuntu1604
-    memory: 1024
+    memory: 256
     cpus: 1
   - name: ubuntu1804
     box: roboxes/ubuntu1804
-    memory: 1024
+    memory: 256
     cpus: 1
   - name: ubuntu2004
     box: roboxes/ubuntu2004
-    memory: 1024
+    memory: 256
     cpus: 1
 provisioner:
   name: ansible


### PR DESCRIPTION
This fixes the current issue with macos-12 runners. We still have some failures in some jobs, some follow up PRs will take care of those