### PR TITLE
fix unreachable host keyrings

### DIFF
--- a/apt/apt.go
+++ b/apt/apt.go
@@ -259,27 +259,29 @@ func NewBackend(target *types.Target, aptConfigDir string, logger types.Logger) 
 	}
 
 	for i, repo := range repoList {
-		if repo.Enabled && !repo.SourceRepo {
-			prefix := target.Distro.Display
-			repoID := fmt.Sprintf("%s-%d", prefix, i)
-
-			var components []string
-			if repo.Components != "" {
-				components = strings.Split(repo.Components, " ")
-			}
-
-			remoteRepo, err := deb.NewRemoteRepo(repoID, repo.URI, repo.Distribution, components, []string{debArch}, false, false, false)
-			if err != nil {
-				return nil, err
-			}
-
-			if err := backend.repoCollection.Add(remoteRepo); err != nil {
-				backend.Close()
-				return nil, fmt.Errorf("failed to add collection: %w", err)
-			}
-
-			backend.logger.Debugf("Added repository '%s' %s %s %v %v", repoID, repo.URI, repo.Distribution, components, debArch)
+		if !repo.Enabled || repo.SourceRepo {
+			continue
 		}
+
+		prefix := target.Distro.Display
+		repoID := fmt.Sprintf("%s-%d", prefix, i)
+
+		var components []string
+		if repo.Components != "" {
+			components = strings.Split(repo.Components, " ")
+		}
+
+		remoteRepo, err := deb.NewRemoteRepo(repoID, repo.URI, repo.Distribution, components, []string{debArch}, false, false, false)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := backend.repoCollection.Add(remoteRepo); err != nil {
+			backend.Close()
+			return nil, fmt.Errorf("failed to add collection: %w", err)
+		}
+
+		backend.logger.Debugf("Added repository '%s' %s %s %v %v", repoID, repo.URI, repo.Distribution, components, debArch)
 	}
 
 	return backend, nil


### PR DESCRIPTION
In some cases, repositories can be signed by keys that nikos cannot reach, example:
```
deb [signed-by=/usr/share/keyrings/cuda-archive-keyring.gpg] https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/ /
```
since `/host/usr` doesn't exist.

In this case it's better to not even add the repository since it will fail when downloading.

Tested and validated using a custom agent build