### PR TITLE
bump minimal go version to 1.21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.20"
+          go-version: "1.21"
 
       - name: Cache Go modules
         uses: actions/cache@v4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/nikos
 
-go 1.20
+go 1.21
 
 require (
 	cloud.google.com/go/storage v1.39.1


### PR DESCRIPTION
1.21 is the latest go version supported by golang maintainers