### PR TITLE
re-enable opensuse 15 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,10 +63,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [
+        platform:
+          [
             "fedora",
             "centos",
-            # "opensuse",
+            "opensuse",
             "debian",
             "ubuntu",
             "oracle",

--- a/tests/molecule/opensuse-container/molecule.yml
+++ b/tests/molecule/opensuse-container/molecule.yml
@@ -8,14 +8,10 @@ platforms:
     box: roboxes/opensuse15
     memory: 512
     cpus: 1
-  - name: opensuse42
-    box: generic/opensuse42
-    memory: 512
-    cpus: 1
 provisioner:
   name: ansible
   env:
-    TEST_TYPE: 'container'
+    TEST_TYPE: "container"
     NIKOS_PREFIX: sudo docker exec -ti debian
   playbooks:
     converge: ../resources/playbooks/converge.yml

--- a/tests/molecule/opensuse-host/molecule.yml
+++ b/tests/molecule/opensuse-host/molecule.yml
@@ -8,14 +8,10 @@ platforms:
     box: roboxes/opensuse15
     memory: 512
     cpus: 1
-  - name: opensuse42
-    box: generic/opensuse42
-    memory: 512
-    cpus: 1
 provisioner:
   name: ansible
   env:
-    TEST_TYPE: 'host'
+    TEST_TYPE: "host"
   playbooks:
     converge: ../resources/playbooks/converge.yml
     verify: ../resources/playbooks/verify.yml


### PR DESCRIPTION
This test re-enables `roboxes/opensuse15` tests in the CI. It was identified that `generic/opensuse42` was the faulty image