### PR TITLE
run build and check glibc tests on ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,20 +42,6 @@ jobs:
           path: /opt/nikos
           retention-days: 1
 
-  verify-glibc:
-    name: Check GLIBC references
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download the nikos artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: nikos-archive
-          path: /opt/nikos
-
-      - name: Fail if there are references to GLIBC >= 2.18
-        run: objdump -p /opt/nikos/bin/nikos | egrep -zqv 'GLIBC_2\.(1[8-9]|[2-9][0-9])'
-
   molecule-tests:
     name: Molecule tests
     needs: build


### PR DESCRIPTION
Now that there is no cgo anymore in this lib the glibc version is no longer an issue.
This PR upgrades the ubuntu version in the tests (since ubuntu 20.04 is no longer available on github actions anyway). And removes the glibc check.